### PR TITLE
Fixed the package name to match the composer package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Installation
 
 ```bash
-$ composer require loadsys/cakephp-sitemap
+$ composer require loadsys/cakephp_sitemap
 ```
 
 In your `config/bootstrap.php` file, add:


### PR DESCRIPTION
As the package name on Packagist and in the `composer.json` uses an underscore instead of a hyphen