### PR TITLE
Fix xml serialization

### DIFF
--- a/src/Controller/SitemapsController.php
+++ b/src/Controller/SitemapsController.php
@@ -30,5 +30,6 @@ class SitemapsController extends AppController {
 		}
 
 		$this->set('data', $data);
+		$this->set('_serialize', false);
 	}
 }

--- a/tests/TestCase/Controller/SitemapsControllerTest.php
+++ b/tests/TestCase/Controller/SitemapsControllerTest.php
@@ -67,9 +67,15 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 			'\Sitemap\Controller\SitemapsController',
 			['set']
 		);
-		$Controller->expects($this->once())
+
+		$Controller->expects($this->at(0))
 			->method('set')
 			->with('data', [])
+			->will($this->returnValue(true));
+
+		$Controller->expects($this->at(1))
+			->method('set')
+			->with('_serialize', false)
 			->will($this->returnValue(true));
 
 		$Controller->index();
@@ -89,9 +95,15 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 			'\Sitemap\Controller\SitemapsController',
 			['set', 'loadModel']
 		);
-		$Controller->expects($this->once())
+
+		$Controller->expects($this->at(1))
 			->method('set')
 			->with('data', ['Pages' => $pagesFindQuery])
+			->will($this->returnValue(true));
+
+		$Controller->expects($this->at(2))
+			->method('set')
+			->with('_serialize', false)
 			->will($this->returnValue(true));
 
 		$Controller->expects($this->once())


### PR DESCRIPTION
Right now, xml serialization is automatically taking a scaffold xml view instead of taking the given xml view by your plugin.

Setting `_serialize` to false fixes this issue.