### PR TITLE
Fix sitemap route

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -3,9 +3,13 @@ use Cake\Routing\Router;
 
 Router::plugin(
 	'Sitemap',
-	['path' => '/sitemap'],
+	['path' => '/'],
 	function ($routes) {
 		$routes->extensions(['xml']);
-		$routes->fallbacks('DashedRoute');
+		$routes->connect('/sitemap', [
+			'controller' => 'Sitemaps',
+			'plugin' => 'Sitemap',
+			'action' => 'index'
+		]);
 	}
 );

--- a/tests/App/Template/Layout/default.ctp
+++ b/tests/App/Template/Layout/default.ctp
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<?= $this->Html->charset() ?>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>
+		<?= $this->fetch('title') ?>
+	</title>
+	<?= $this->Html->meta('icon') ?>
+
+	<?= $this->fetch('meta') ?>
+	<?= $this->fetch('css') ?>
+	<?= $this->fetch('script') ?>
+</head>
+<body>
+	<?= $this->Flash->render() ?>
+	<div class="container clearfix">
+		<?= $this->fetch('content') ?>
+	</div>
+</body>
+</html>

--- a/tests/TestCase/Controller/SitemapsControllerTest.php
+++ b/tests/TestCase/Controller/SitemapsControllerTest.php
@@ -103,4 +103,10 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 
 		$Controller->index();
 	}
+
+	public function testIndexAccess() {
+		$this->get('/sitemap.xml');
+
+		$this->assertResponseOk();
+	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,11 +3,11 @@ define('ROOT', dirname(__DIR__));
 define('TMP', ROOT . DS . 'tmp' . DS);
 define('LOGS', TMP . 'logs' . DS);
 define('CACHE', TMP . 'cache' . DS);
-define('APP', sys_get_temp_dir());
-define('APP_DIR', 'src');
+define('APP_DIR', 'App');
+define('APP', ROOT . DS . 'tests' . DS . APP_DIR . DS);
 define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
-define('CAKE', CORE_PATH . APP_DIR . DS);
+define('CAKE', CORE_PATH . 'src' . DS);
 
 define('WWW_ROOT', ROOT . DS . 'webroot' . DS);
 define('CONFIG', dirname(__FILE__) . DS . 'config' . DS);
@@ -20,6 +20,9 @@ require CORE_PATH . 'config/bootstrap.php';
 Cake\Core\Configure::write('App', [
 	'namespace' => 'App',
 	'encoding' => 'UTF-8',
+	'paths' => [
+		'templates' => [APP . 'Template' . DS],
+	],
 ]);
 Cake\Core\Configure::write('debug', true);
 
@@ -73,5 +76,7 @@ Cake\Datasource\ConnectionManager::config('test', [
 	'quoteIdentifiers' => true,
 	'cacheMetadata' => true,
 ]);
+
+Cake\Routing\DispatcherFactory::add('Routing');
 
 class_alias('Cake\Controller\Controller', 'App\Controller\AppController');

--- a/tests/config/routes.php
+++ b/tests/config/routes.php
@@ -4,6 +4,10 @@ namespace Sitemap\Test\App\Config;
 use Cake\Routing\Router;
 
 Router::scope('/', function ($routes) {
-	$routes->connect('/:controller', ['action' => 'index'], ['routeClass' => 'DashedRoute']);
-	$routes->connect('/:controller/:action/*', [], ['routeClass' => 'DashedRoute']);
+	$routes->connect('/pages/view/:id', [
+		'controller' => 'Pages',
+		'action' => 'view',
+	], ['pass' => ['id']]);
 });
+
+require ROOT . DS . 'config/routes.php';


### PR DESCRIPTION
Fixes #37

I've tried to add a test to check it, but it crashes due to the `routes.php` file not being loaded properly. Sorry for that.

The problem with the routes was that you were using the `dashedRoutes` fallback, which was generating urls of this type (extracted from RoutesShell):

    | sitemap._controller:index               | /sitemap/:controller                                       | {"action":"index","plugin":"Sitemap"}                                                              |
    | sitemap._controller:_action             | /sitemap/:controller/:action/*                             | {"action":"index","plugin":"Sitemap"}

With my changes, the expected route now is `/sitemap(.xml)?`:

    | sitemap.sitemaps:index                  | /sitemap                                                   | {"controller":"Sitemaps","plugin":"Sitemap","action":"index"}                                      |
