### PR TITLE
Resolves #50

### DIFF
--- a/src/Controller/SitemapsController.php
+++ b/src/Controller/SitemapsController.php
@@ -25,8 +25,8 @@ class SitemapsController extends AppController {
 		}
 
 		foreach ($tablesToList as $table) {
-			$this->loadModel($table);
-			$data[$table] = $this->{$table}->find('forSitemap');
+			$tableInstance = $this->loadModel($table);
+			$data[$table] = $tableInstance->find('forSitemap');
 		}
 
 		$this->set('data', $data);

--- a/tests/TestCase/Controller/SitemapsControllerTest.php
+++ b/tests/TestCase/Controller/SitemapsControllerTest.php
@@ -113,7 +113,7 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 		$Controller->expects($this->once())
 			->method('loadModel')
 			->with('Pages')
-			->will($this->returnValue(true));
+			->willReturn($this->Pages);
 
 		$Controller->Pages = $this->Pages;
 

--- a/tests/TestCase/Controller/SitemapsControllerTest.php
+++ b/tests/TestCase/Controller/SitemapsControllerTest.php
@@ -44,6 +44,8 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 	public function tearDown() {
 		unset($this->Pages);
 
+		Configure::clear();
+
 		parent::tearDown();
 	}
 
@@ -127,4 +129,9 @@ class SitemapsControllerTestCase extends IntegrationTestCase {
 
 		$this->assertResponseOk();
 	}
+
+	public function testLoadingPluginTables()
+    {
+        
+    }
 }


### PR DESCRIPTION
This patch will allow the controller to correctly reference tables after they have been loaded with `loadModel`.

I have also included a new test case for namespaced tables from plugins. I've had to update an existing test because it was expecting `loadModel` to return a boolean, which it doesn't, as it returns a table instance.