### PR TITLE
Fixed the generation of urls to work with plugin table classes

### DIFF
--- a/src/Model/Behavior/SitemapBehavior.php
+++ b/src/Model/Behavior/SitemapBehavior.php
@@ -74,7 +74,7 @@ class SitemapBehavior extends Behavior {
 			[
 				'plugin' => null,
 				'prefix' => null,
-				'controller' => $this->_table->registryAlias(),
+				'controller' => $this->_table->alias(),
 				'action' => 'view',
 				$entity->{$this->_table->primaryKey()},
 			],

--- a/tests/TestCase/Model/Behavior/SitemapBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SitemapBehaviorTest.php
@@ -142,6 +142,11 @@ class SitemapBehaviorTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Test the url for a plugin entity is correct
+	 *
+	 * @return void
+	 */
 	public function testReturnUrlForPluginEntity() {
 		Router::connect('/posts/view/:id', ['controller' => 'Posts', 'action' => 'view'], ['id' => '[\d]+', 'pass' => ['id']]);
 


### PR DESCRIPTION
Following on from fixing the loading of plugin table classes in #51, it seems that generating links for plugin table classes has the same issue.

I have fixed that. I have stuck with the deprecated method because upgrading the plugin is outside of scope for this pull request, and would also push the minimum requirement for the plugin to CakePHP 3.4+, and changing the requirements are outside the scope of this pull request.