### PR TITLE
Refactor extensions() to setExtensions()

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -5,7 +5,7 @@ Router::plugin(
 	'Sitemap',
 	['path' => '/sitemap'],
 	function ($routes) {
-		$routes->extensions(['xml']);
+		$routes->setExtensions(['xml']);
 		$routes->connect('/', [
 			'controller' => 'Sitemaps',
 			'plugin' => 'Sitemap',


### PR DESCRIPTION
`extensions()` was deprecated in CakePHP. v3.3.9 Use `setExtensions()` instead.